### PR TITLE
fix: re-render layout when async component is resolved

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,15 @@ export function createRouterLayout(
       }
     },
 
+    provide() {
+      return {
+        $_routerLayout_notifyUpdate: () => {
+          const matched = this.$route.matched
+          this.layoutName = findLayoutName(matched)
+        }
+      }
+    },
+
     beforeRouteEnter(to, _from, next) {
       next((vm: any) => {
         vm.layoutName = findLayoutName(to.matched)
@@ -70,6 +79,21 @@ export function createRouterLayout(
     }
   })
 }
+
+Vue.mixin({
+  inject: {
+    $_routerLayout_notifyUpdate: {
+      default: null
+    }
+  },
+
+  beforeUpdate() {
+    const notify = (this as any).$_routerLayout_notifyUpdate
+    if (notify) {
+      notify()
+    }
+  }
+})
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`RouterLayout component uses the leaf component's layout option 1`] = `"
 
 exports[`RouterLayout component works with async component 1`] = `"<div>Foo <p>Test1</p></div>"`;
 
-exports[`RouterLayout component works with async component 2`] = `"<div>Default <p>Test2</p></div>"`;
+exports[`RouterLayout component works with async component 2`] = `"<div>Bar <p>Test2</p></div>"`;
 
 exports[`RouterLayout component works with component constructor 1`] = `"<div>Foo <p>Test1</p></div>"`;
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -10,7 +10,9 @@ exports[`RouterLayout component uses the leaf component's layout option 1`] = `"
 
 exports[`RouterLayout component works with async component 1`] = `"<div>Foo <p>Test1</p></div>"`;
 
-exports[`RouterLayout component works with async component 2`] = `"<div>Bar <p>Test2</p></div>"`;
+exports[`RouterLayout component works with async component 2`] = `"<div>Foo <p>Test1</p></div>"`;
+
+exports[`RouterLayout component works with async component 3`] = `"<div>Bar <p>Test2</p></div>"`;
 
 exports[`RouterLayout component works with component constructor 1`] = `"<div>Foo <p>Test1</p></div>"`;
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -170,6 +170,7 @@ describe('RouterLayout component', () => {
       return new Promise(resolve => {
         setTimeout(() => {
           resolve({
+            layout: 'bar',
             template: '<p>Test2</p>'
           })
         }, 100)

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -187,10 +187,18 @@ describe('RouterLayout component', () => {
         component: Test2
       }
     ])
+
+    // Foo - Test1
     expect(wrapper.html()).toMatchSnapshot()
+
     wrapper.vm.$router.push('/test')
 
+    // Foo - Test1 (Should not change layout until the async component is resolved)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.html()).toMatchSnapshot()
+
     setTimeout(() => {
+      // Bar - Test2 (Should update layout after async component is resolved)
       expect(wrapper.html()).toMatchSnapshot()
       done()
     }, 200)


### PR DESCRIPTION
fix https://github.com/ktsn/vue-cli-plugin-auto-routing/issues/1

Since we don't have a way to notice descendant async components are resolved, we need to add a global mixin and always calling `provide`d notification method. So the `<RouterLayout>` component can collect layout name when corresponding async component is resolved.