### PR TITLE
fix: avoid calling lifecycle hook twice when using async component

### DIFF
--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -20,6 +20,12 @@ exports[`RouterLayout component works with async component 2`] = `"<div>Foo <p>T
 
 exports[`RouterLayout component works with async component 3`] = `"<div>Bar <p>Test2</p></div>"`;
 
+exports[`RouterLayout component works with async component with default export 1`] = `"<div>Foo <p>Test1</p></div>"`;
+
+exports[`RouterLayout component works with async component with default export 2`] = `"<div>Foo <p>Test1</p></div>"`;
+
+exports[`RouterLayout component works with async component with default export 3`] = `"<div>Bar <p>Dummy</p></div>"`;
+
 exports[`RouterLayout component works with component constructor 1`] = `"<div>Foo <p>Test1</p></div>"`;
 
 exports[`RouterLayout component works with component constructor 2`] = `"<div>Default <p>Test2</p></div>"`;

--- a/test/dummy.ts
+++ b/test/dummy.ts
@@ -1,0 +1,4 @@
+export default {
+  layout: 'bar',
+  template: '<p>Dummy</p>'
+}


### PR DESCRIPTION
fix #5 

Like nuxt does, vue-router-layout will resolve all async components for a route before mounting it now.