### PR TITLE
feat: Support Vue 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,28 @@ You may want to use [vue-cli-plugin-auto-routing](https://github.com/ktsn/vue-cl
 $ npm install vue-router-layout
 ```
 
+## Supported Vue Version
+
+0.2.0 or newer only supports Vue >= 3.0.0. If you want to use vue-router-layout with Vue v2, try 0.1.x.
+
 ## Overview
 
-Create `<RouterLayout>` component by passing a callback which resolves layout component to `createRouterLayout`. The callback will receives a string of layout type and expect returning a promise resolves a layout component.
+First of all, install vue-router-layout plugin to your Vue app instance.
+
+```js
+import { createApp } from 'vue'
+import VueRouterLayout from 'vue-router-layout'
+import App from './App.vue'
+
+const app = createApp(App)
+
+// Install vue-router-layout
+app.use(VueRouterLayout)
+
+app.mount('#app')
+```
+
+Then, create `<RouterLayout>` component by passing a callback which resolves layout component to `createRouterLayout`. The callback will receives a string of layout type and expect returning a promise resolves a layout component.
 
 ```js
 import { createRouterLayout } from 'vue-router-layout'
@@ -24,11 +43,11 @@ const RouterLayout = createRouterLayout(layout => {
 })
 ```
 
-Then, you pass `<RouterLayout>` to Vue Router's `routes` option with some children components.
+Pass `<RouterLayout>` to Vue Router's `routes` option with some children components.
 
 ```js
-import Vue from 'vue'
-import Router from 'vue-router'
+
+import { createRouter, createWebHistory } from 'vue-router'
 import { createRouterLayout } from 'vue-router-layout'
 
 // Create <RouterLayout> component.
@@ -37,9 +56,8 @@ const RouterLayout = createRouterLayout(layout => {
   return import('@/layouts/' + layout + '.vue')
 })
 
-Vue.use(Router)
-
-export default new Router({
+export default createRouter({
+  history: createWebHistory(),
   routes: [
     {
       path: '/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1326,27 +1326,180 @@
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
-    "@vue/test-utils": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.1.2.tgz",
-      "integrity": "sha512-utbIL7zn9c+SjhybPwh48lpWCiluFCbP1yyRNAy1fQsw/6hiNFioaWy05FoVAFIZXC5WwBf+5r4ypfM1j/nI4A==",
+    "@vue/compiler-core": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.5.tgz",
+      "integrity": "sha512-iFXwk2gmU/GGwN4hpBwDWWMLvpkIejf/AybcFtlQ5V1ur+5jwfBaV0Y1RXoR6ePfBPJixtKZ3PmN+M+HgMAtfQ==",
       "dev": true,
       "requires": {
-        "dom-event-types": "^1.0.0",
-        "lodash": "^4.17.15",
-        "pretty": "^2.0.0"
+        "@babel/parser": "^7.12.0",
+        "@babel/types": "^7.12.0",
+        "@vue/shared": "3.0.5",
+        "estree-walker": "^2.0.1",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/parser": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+          "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.12.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+          "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        }
       }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.5.tgz",
+      "integrity": "sha512-HSOSe2XSPuCkp20h4+HXSiPH9qkhz6YbW9z9ZtL5vef2T2PMugH7/osIFVSrRZP/Ul5twFZ7MIRlp8tPX6e4/g==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-core": "3.0.5",
+        "@vue/shared": "3.0.5"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.5.tgz",
+      "integrity": "sha512-uOAC4X0Gx3SQ9YvDC7YMpbDvoCmPvP0afVhJoxRotDdJ+r8VO3q4hFf/2f7U62k4Vkdftp6DVni8QixrfYzs+w==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.12.0",
+        "@babel/types": "^7.12.0",
+        "@vue/compiler-core": "3.0.5",
+        "@vue/compiler-dom": "3.0.5",
+        "@vue/compiler-ssr": "3.0.5",
+        "@vue/shared": "3.0.5",
+        "consolidate": "^0.16.0",
+        "estree-walker": "^2.0.1",
+        "hash-sum": "^2.0.0",
+        "lru-cache": "^5.1.1",
+        "magic-string": "^0.25.7",
+        "merge-source-map": "^1.1.0",
+        "postcss": "^7.0.32",
+        "postcss-modules": "^3.2.2",
+        "postcss-selector-parser": "^6.0.4",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/parser": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+          "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.12.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+          "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.25.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        }
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.5.tgz",
+      "integrity": "sha512-Wm//Kuxa1DpgjE4P9W0coZr8wklOfJ35Jtq61CbU+t601CpPTK4+FL2QDBItaG7aoUUDCWL5nnxMkuaOgzTBKg==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-dom": "3.0.5",
+        "@vue/shared": "3.0.5"
+      }
+    },
+    "@vue/reactivity": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.5.tgz",
+      "integrity": "sha512-3xodUE3sEIJgS7ntwUbopIpzzvi7vDAOjVamfb2l+v1FUg0jpd3gf62N2wggJw3fxBMr+QvyxpD+dBoxLsmAjw==",
+      "dev": true,
+      "requires": {
+        "@vue/shared": "3.0.5"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.5.tgz",
+      "integrity": "sha512-Cnyi2NqREwOLcTEsIi1DQX1hHtkVj4eGm4hBG7HhokS05DqpK4/80jG6PCCnCH9rIJDB2FqtaODX397210plXg==",
+      "dev": true,
+      "requires": {
+        "@vue/reactivity": "3.0.5",
+        "@vue/shared": "3.0.5"
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.5.tgz",
+      "integrity": "sha512-iilX1KySeIzHHtErT6Y44db1rhWK5tAI0CiJIPr+SJoZ2jbjoOSE6ff/jfIQakchbm1d6jq6VtRVnp5xYdOXKA==",
+      "dev": true,
+      "requires": {
+        "@vue/runtime-core": "3.0.5",
+        "@vue/shared": "3.0.5",
+        "csstype": "^2.6.8"
+      }
+    },
+    "@vue/shared": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.5.tgz",
+      "integrity": "sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw==",
+      "dev": true
+    },
+    "@vue/test-utils": {
+      "version": "2.0.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.0.0-beta.13.tgz",
+      "integrity": "sha512-Au+yGMBPvrtcmPP6W4ielTbNJd3equxVOq1iL0DvpAZJwkGOrdBfFTomMhANODiBVyIEE8HMxhr7YIwDHWO36w==",
+      "dev": true
     },
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
-      "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
@@ -1725,6 +1878,18 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1956,45 +2121,13 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "condense-newlines": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
-      "integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
+    "consolidate": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
+      "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-whitespace": "^0.3.0",
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "config-chain": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
+        "bluebird": "^3.7.2"
       }
     },
     "convert-source-map": {
@@ -2042,6 +2175,12 @@
         }
       }
     },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
+    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -2065,6 +2204,12 @@
         }
       }
     },
+    "csstype": {
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+      "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2084,12 +2229,6 @@
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       }
-    },
-    "de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
-      "dev": true
     },
     "debug": {
       "version": "4.1.1",
@@ -2213,12 +2352,6 @@
         }
       }
     },
-    "dom-event-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.0.0.tgz",
-      "integrity": "sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==",
-      "dev": true
-    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -2238,22 +2371,16 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "editorconfig": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.5",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
-      }
-    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
     },
     "end-of-stream": {
@@ -2661,6 +2788,15 @@
       "dev": true,
       "optional": true
     },
+    "generic-names": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
+      "integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -2804,10 +2940,10 @@
         }
       }
     },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+    "hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
       "dev": true
     },
     "hosted-git-info": {
@@ -2857,6 +2993,21 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "icss-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
     "import-local": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -2873,6 +3024,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2887,12 +3044,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "ip-regex": {
@@ -3031,12 +3182,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "is-whitespace": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
-      "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
       "dev": true
     },
     "is-windows": {
@@ -5184,27 +5329,6 @@
         }
       }
     },
-    "js-beautify": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.13.0.tgz",
-      "integrity": "sha512-/Tbp1OVzZjbwzwJQFIlYLm9eWQ+3aYbBXLSaqb1mEJzhcQAfrqMMQYtjb6io+U6KpD0ID4F+Id3/xcjH3l/sqA==",
-      "dev": true,
-      "requires": {
-        "config-chain": "^1.1.12",
-        "editorconfig": "^0.15.3",
-        "glob": "^7.1.3",
-        "mkdirp": "^1.0.4",
-        "nopt": "^5.0.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        }
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5354,6 +5478,28 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "loader-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -5367,6 +5513,12 @@
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.memoize": {
@@ -5391,13 +5543,12 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
       }
     },
     "magic-string": {
@@ -5454,6 +5605,15 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
       }
     },
     "merge-stream": {
@@ -5626,15 +5786,6 @@
             "isexe": "^2.0.0"
           }
         }
-      }
-    },
-    "nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -5883,6 +6034,104 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcss": {
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-3.2.2.tgz",
+      "integrity": "sha512-JQ8IAqHELxC0N6tyCg2UF40pACY5oiL6UpiqqcIFRWqgDYO8B0jnxzoQ0EOpPrWXvcpu6BSbQU/3vSiq7w8Nhw==",
+      "dev": true,
+      "requires": {
+        "generic-names": "^2.0.1",
+        "icss-replace-symbols": "^1.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "postcss": "^7.0.32",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-scope": "^2.2.0",
+        "postcss-modules-values": "^3.0.0",
+        "string-hash": "^1.1.1"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
+      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.32",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+      "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -5894,28 +6143,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
       "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
-    },
-    "pretty": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
-      "integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
-      "dev": true,
-      "requires": {
-        "condense-newlines": "^0.2.1",
-        "extend-shallow": "^2.0.1",
-        "js-beautify": "^1.6.12"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
-      }
     },
     "pretty-format": {
       "version": "26.6.2",
@@ -5976,18 +6203,6 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
       }
-    },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
     },
     "psl": {
       "version": "1.8.0",
@@ -6479,12 +6694,6 @@
       "dev": true,
       "optional": true
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -6767,6 +6976,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
       "dev": true
     },
     "string-length": {
@@ -7159,6 +7374,12 @@
         "set-value": "^2.0.1"
       }
     },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -7220,6 +7441,12 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -7267,26 +7494,21 @@
       }
     },
     "vue": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
-      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==",
-      "dev": true
-    },
-    "vue-router": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.4.9.tgz",
-      "integrity": "sha512-CGAKWN44RqXW06oC+u4mPgHLQQi2t6vLD/JbGRDAXm0YpMv0bgpKuU5bBd7AvMgfTz9kXVRIWKHqRwGEb8xFkA==",
-      "dev": true
-    },
-    "vue-template-compiler": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz",
-      "integrity": "sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.5.tgz",
+      "integrity": "sha512-TfaprOmtsAfhQau7WsomXZ8d9op/dkQLNIq8qPV3A0Vxs6GR5E+c1rfJS1SDkXRQj+dFyfnec7+U0Be1huiScg==",
       "dev": true,
       "requires": {
-        "de-indent": "^1.0.2",
-        "he": "^1.1.0"
+        "@vue/compiler-dom": "3.0.5",
+        "@vue/runtime-dom": "3.0.5",
+        "@vue/shared": "3.0.5"
       }
+    },
+    "vue-router": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.2.tgz",
+      "integrity": "sha512-LCsTSb5H25dZCxjsLasM9UED1BTg9vyTnp0Z9UhwC6QoqgLuHr/ySf7hjI/V0j2+xCKqJtecfmpghk6U8I2e4w==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -7451,9 +7673,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7351,9 +7351,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     },
     "testRegex": "/test/.+\\.spec\\.(js|ts)$",
     "moduleNameMapper": {
-      "^vue$": "vue/dist/vue.common.js"
+      "^vue$": "vue/dist/vue.cjs.js"
     },
     "moduleFileExtensions": [
       "ts",
@@ -57,7 +57,8 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.0",
-    "@vue/test-utils": "^1.0.0-beta.29",
+    "@vue/compiler-sfc": "^3.0.5",
+    "@vue/test-utils": "^2.0.0-beta.13",
     "jest": "^25.1.0",
     "prettier": "2.1.2",
     "rollup": "^2.0.0",
@@ -68,8 +69,7 @@
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.3.3",
     "uglify-js": "^3.4.9",
-    "vue": "^2.6.6",
-    "vue-router": "^3.0.2",
-    "vue-template-compiler": "^2.6.6"
+    "vue": "^3.0.5",
+    "vue-router": "^4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "tslint": "^5.12.1",
     "tslint-config-ktsn": "^2.1.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.3.3",
+    "typescript": "^4.1.3",
     "uglify-js": "^3.4.9",
     "vue": "^3.0.5",
     "vue-router": "^4.0.2"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,6 +20,7 @@ const baseConfig = {
   output: {
     name: capitalize(pkg.name),
     banner,
+    exports: 'named',
     globals: {
       vue: 'Vue',
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   defineComponent,
   defineAsyncComponent,
   App,
-  shallowReactive
+  shallowReactive,
 } from 'vue'
 import { RouteRecord, RouteLocationNormalized } from 'vue-router'
 
@@ -82,7 +82,7 @@ function loadAsyncComponents(route: RouteLocationNormalized): Promise<unknown> {
 function install(app: App) {
   app.mixin({
     beforeCreate() {
-      (this as any).$_routerLayout_installed = true
+      ;(this as any).$_routerLayout_installed = true
     },
 
     inject: {
@@ -92,8 +92,9 @@ function install(app: App) {
     },
 
     async beforeRouteUpdate(to, _from, next) {
-      const notify: ((route: RouteLocationNormalized) => Promise<unknown>) | null = (this as any)
-        .$_routerLayout_notifyRouteUpdate
+      const notify:
+        | ((route: RouteLocationNormalized) => Promise<unknown>)
+        | null = (this as any).$_routerLayout_notifyRouteUpdate
       if (notify) {
         await notify(to)
       }
@@ -111,21 +112,27 @@ export function createRouterLayout(
     data() {
       return {
         layoutName: undefined as string | undefined,
-        layouts: shallowReactive(Object.create(null) as Record<string, ConcreteComponent>),
+        layouts: shallowReactive(
+          Object.create(null) as Record<string, ConcreteComponent>
+        ),
       }
     },
 
     watch: {
       layoutName(name: string | undefined) {
         if (name && !this.layouts[name]) {
-          this.layouts[name] = defineAsyncComponent(() => resolve(name)) as ConcreteComponent
+          this.layouts[name] = defineAsyncComponent(() =>
+            resolve(name)
+          ) as ConcreteComponent
         }
       },
     },
 
     provide() {
       return {
-        $_routerLayout_notifyRouteUpdate: async (to: RouteLocationNormalized) => {
+        $_routerLayout_notifyRouteUpdate: async (
+          to: RouteLocationNormalized
+        ) => {
           await loadAsyncComponents(to)
           this.layoutName = resolveLayoutName(to.matched) || this.layoutName
         },
@@ -133,8 +140,13 @@ export function createRouterLayout(
     },
 
     beforeCreate() {
-      if (process.env.NODE_ENV !== 'production' && !(this as any).$_routerLayout_installed) {
-        console.error('[vue-router-layout] Call app.use(VueRouterLayout) before using the layout component.')
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        !(this as any).$_routerLayout_installed
+      ) {
+        console.error(
+          '[vue-router-layout] Call app.use(VueRouterLayout) before using the layout component.'
+        )
       }
     },
 
@@ -164,7 +176,7 @@ export function createRouterLayout(
 }
 
 export default {
-  install
+  install,
 }
 
 declare module '@vue/runtime-core' {

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,10 @@ function loadAsyncComponents(route: RouteLocationNormalized): Promise<unknown> {
 
 function install(app: App) {
   app.mixin({
+    beforeCreate() {
+      (this as any).$_routerLayout_installed = true
+    },
+
     inject: {
       $_routerLayout_notifyRouteUpdate: {
         default: null,
@@ -125,6 +129,12 @@ export function createRouterLayout(
           await loadAsyncComponents(to)
           this.layoutName = resolveLayoutName(to.matched) || this.layoutName
         },
+      }
+    },
+
+    beforeCreate() {
+      if (process.env.NODE_ENV !== 'production' && !(this as any).$_routerLayout_installed) {
+        console.error('[vue-router-layout] Call app.use(VueRouterLayout) before using the layout component.')
       }
     },
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1,77 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RouterLayout component inherits layout value from super constructor 1`] = `
-"<div>Foo <p>component</p>
-</div>"
-`;
+exports[`RouterLayout component prioritizes mixins option than extends 1`] = `"<div>Bar <p>component</p></div>"`;
 
-exports[`RouterLayout component prioritizes mixins option than extends 1`] = `
-"<div>Bar <p>component</p>
-</div>"
-`;
+exports[`RouterLayout component pulls layout value from extends 1`] = `"<div>Foo <p>component</p></div>"`;
 
-exports[`RouterLayout component pulls layout value from extends 1`] = `
-"<div>Foo <p>component</p>
-</div>"
-`;
+exports[`RouterLayout component shows default layout 1`] = `"<div>Default <p>component</p></div>"`;
 
-exports[`RouterLayout component shows default layout 1`] = `
-"<div>Default <p>component</p>
-</div>"
-`;
+exports[`RouterLayout component shows named layout 1`] = `"<div>Foo <p>component</p></div>"`;
 
-exports[`RouterLayout component shows named layout 1`] = `
-"<div>Foo <p>component</p>
-</div>"
-`;
+exports[`RouterLayout component updates layout when route is changed 1`] = `"<div>Bar <p>Test2</p></div>"`;
 
-exports[`RouterLayout component updates layout when route is changed 1`] = `
-"<div>Bar <p>Test2</p>
-</div>"
-`;
+exports[`RouterLayout component uses the leaf component's layout option 1`] = `"<div>Bar <div>Test1 <p>Test2</p></div></div>"`;
 
-exports[`RouterLayout component uses the leaf component's layout option 1`] = `
-"<div>Bar <div>Test1 <p>Test2</p>
-  </div>
-</div>"
-`;
+exports[`RouterLayout component works with async component 1`] = `"<div>Foo <p>Test1</p></div>"`;
 
-exports[`RouterLayout component works with async component 1`] = `
-"<div>Foo <p>Test1</p>
-</div>"
-`;
+exports[`RouterLayout component works with async component 2`] = `"<div>Foo <p>Test1</p></div>"`;
 
-exports[`RouterLayout component works with async component 2`] = `
-"<div>Foo <p>Test1</p>
-</div>"
-`;
+exports[`RouterLayout component works with async component 3`] = `"<div>Bar <p>Test2</p></div>"`;
 
-exports[`RouterLayout component works with async component 3`] = `
-"<div>Bar <p>Test2</p>
-</div>"
-`;
+exports[`RouterLayout component works with async component with default export 1`] = `"<div>Foo <p>Test1</p></div>"`;
 
-exports[`RouterLayout component works with async component with default export 1`] = `
-"<div>Foo <p>Test1</p>
-</div>"
-`;
+exports[`RouterLayout component works with async component with default export 2`] = `"<div>Foo <p>Test1</p></div>"`;
 
-exports[`RouterLayout component works with async component with default export 2`] = `
-"<div>Foo <p>Test1</p>
-</div>"
-`;
+exports[`RouterLayout component works with async component with default export 3`] = `"<div>Bar <p>Dummy</p></div>"`;
 
-exports[`RouterLayout component works with async component with default export 3`] = `
-"<div>Bar <p>Dummy</p>
-</div>"
-`;
+exports[`RouterLayout component works with component constructor 1`] = `"<div>Foo <p>Test1</p></div>"`;
 
-exports[`RouterLayout component works with component constructor 1`] = `
-"<div>Foo <p>Test1</p>
-</div>"
-`;
-
-exports[`RouterLayout component works with component constructor 2`] = `
-"<div>Default <p>Test2</p>
-</div>"
-`;
+exports[`RouterLayout component works with component constructor 2`] = `"<div>Default <p>Test2</p></div>"`;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -333,4 +333,10 @@ describe('RouterLayout component', () => {
     ])
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('warn when the layout component is used before installing the plugin', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {/* nothing */})
+    _mount(RouterLayout)
+    expect(console.error).toHaveBeenCalledWith('[vue-router-layout] Call app.use(VueRouterLayout) before using the layout component.')
+  })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -39,8 +39,8 @@ async function mount(children: RouteRecordRaw[]) {
 
   const wrapper = _mount(Root, {
     global: {
-      plugins: [router, VueRouterLayout]
-    }
+      plugins: [router, VueRouterLayout],
+    },
   })
   await router.push('/')
   await wrapper.vm.$nextTick()
@@ -335,8 +335,12 @@ describe('RouterLayout component', () => {
   })
 
   it('warn when the layout component is used before installing the plugin', () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {/* nothing */})
+    jest.spyOn(console, 'error').mockImplementation(() => {
+      /* nothing */
+    })
     _mount(RouterLayout)
-    expect(console.error).toHaveBeenCalledWith('[vue-router-layout] Call app.use(VueRouterLayout) before using the layout component.')
+    expect(console.error).toHaveBeenCalledWith(
+      '[vue-router-layout] Call app.use(VueRouterLayout) before using the layout component.'
+    )
   })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,12 +1,7 @@
 import { mount as _mount } from '@vue/test-utils'
-import Vue, { Component, ComponentOptions } from 'vue'
-import Router, { RouteConfig } from 'vue-router'
-import { createRouterLayout } from '../src/index'
-
-Vue.config.productionTip = false
-Vue.config.devtools = false
-
-Vue.use(Router)
+import { defineComponent, Component, ComponentOptions } from 'vue'
+import { createRouter, createMemoryHistory, RouteRecordRaw } from 'vue-router'
+import VueRouterLayout, { createRouterLayout } from '../src/index'
 
 const layouts: Record<string, Component> = {
   default: {
@@ -26,9 +21,9 @@ const RouterLayout = createRouterLayout((layout) => {
   return Promise.resolve(layouts[layout])
 })
 
-async function mount(children: RouteConfig[]) {
-  const router = new Router({
-    mode: 'abstract',
+async function mount(children: RouteRecordRaw[]) {
+  const router = createRouter({
+    history: createMemoryHistory(),
     routes: [
       {
         path: '/',
@@ -38,14 +33,18 @@ async function mount(children: RouteConfig[]) {
     ],
   })
 
-  const Root = Vue.extend({
+  const Root = defineComponent({
     template: '<router-view/>',
   })
 
   const wrapper = _mount(Root, {
-    router,
+    global: {
+      plugins: [router, VueRouterLayout]
+    }
   })
   await router.push('/')
+  await wrapper.vm.$nextTick()
+  await wrapper.vm.$nextTick()
   await wrapper.vm.$nextTick()
   return wrapper
 }
@@ -133,12 +132,12 @@ describe('RouterLayout component', () => {
   })
 
   it('works with component constructor', async () => {
-    const Test1 = Vue.extend({
+    const Test1 = defineComponent({
       layout: 'foo',
       template: '<p>Test1</p>',
     })
 
-    const Test2 = Vue.extend({
+    const Test2 = defineComponent({
       template: '<p>Test2</p>',
     })
 
@@ -167,7 +166,7 @@ describe('RouterLayout component', () => {
     }
 
     const Test2 = () => {
-      return new Promise<ComponentOptions<Vue>>((resolve) => {
+      return new Promise<ComponentOptions>((resolve) => {
         setTimeout(() => {
           resolve({
             layout: 'bar',
@@ -301,24 +300,6 @@ describe('RouterLayout component', () => {
       extends: Super,
       template: '<p>component</p>',
     }
-
-    const wrapper = await mount([
-      {
-        path: '',
-        component: Comp,
-      },
-    ])
-    expect(wrapper.html()).toMatchSnapshot()
-  })
-
-  it('inherits layout value from super constructor', async () => {
-    const Super = Vue.extend({
-      layout: 'foo',
-    })
-
-    const Comp = Super.extend({
-      template: '<p>component</p>',
-    })
 
     const wrapper = await mount([
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "es2015",
     "moduleResolution": "node",
     "lib": [
-      "es2015",
+      "ES2020",
       "dom"
     ],
     "strict": true,


### PR DESCRIPTION
It no longer supports Vue <= 2.

### Breaking Change

Users have to `install` vue-router-layout plugin before using the layout component.

```js
import { createApp } from 'vue'
import VueRouterLayout from 'vue-router-layout'
import App from './App.vue'

const app = createApp(App)

// Install vue-router-layout
app.use(VueRouterLayout)

app.mount('#app')
```