### PR TITLE
feat: handle lazy component loading in router hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,7 @@ $ npm install vue-router-layout
 
 ## Overview
 
-First of all, install vue-router-layout plugin to your Vue app instance.
-
-```js
-import { createApp } from 'vue'
-import VueRouterLayout from 'vue-router-layout'
-import App from './App.vue'
-
-const app = createApp(App)
-
-// Install vue-router-layout
-app.use(VueRouterLayout)
-
-app.mount('#app')
-```
-
-Then, create `<RouterLayout>` component by passing a callback which resolves layout component to `createRouterLayout`. The callback will receives a string of layout type and expect returning a promise resolves a layout component.
+Create `<RouterLayout>` component by passing a callback which resolves layout component to `createRouterLayout`. The callback will receives a string of layout type and expect returning a promise resolves a layout component.
 
 ```js
 import { createRouterLayout } from 'vue-router-layout'

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ function normalizeEsModuleComponent(
 
 function install() {
   console.info(
-    '[vue-router-layout] Vue.use(VueRouterLayout) is no longer needed. You can sefely remove it.'
+    '[vue-router-layout] app.use(VueRouterLayout) is no longer needed. You can sefely remove it.'
   )
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,6 @@ import {
   ConcreteComponent,
   h,
   defineComponent,
-  defineAsyncComponent,
-  App,
   shallowReactive,
 } from 'vue'
 import { RouteRecord, RouteLocationNormalized } from 'vue-router'
@@ -65,11 +63,7 @@ function loadAsyncComponents(route: RouteLocationNormalized): Promise<unknown> {
       if (isAsync) {
         promises.push(
           component().then((loaded: any) => {
-            const isEsModule =
-              loaded.__esModule ||
-              (typeof Symbol !== 'undefined' &&
-                loaded[Symbol.toStringTag] === 'Module')
-            record.components[key] = isEsModule ? loaded.default : loaded
+            record.components[key] = normalizeEsModuleComponent(loaded)
           })
         )
       }
@@ -79,28 +73,20 @@ function loadAsyncComponents(route: RouteLocationNormalized): Promise<unknown> {
   return Promise.all(promises)
 }
 
-function install(app: App) {
-  app.mixin({
-    beforeCreate() {
-      ;(this as any).$_routerLayout_installed = true
-    },
+function normalizeEsModuleComponent(
+  comp: Component | { default: Component }
+): Component {
+  const c: any = comp
+  const isEsModule =
+    c.__esModule ||
+    (typeof Symbol !== 'undefined' && c[Symbol.toStringTag] === 'Module')
+  return isEsModule ? c.default : c
+}
 
-    inject: {
-      $_routerLayout_notifyRouteUpdate: {
-        default: null,
-      },
-    },
-
-    async beforeRouteUpdate(to, _from, next) {
-      const notify:
-        | ((route: RouteLocationNormalized) => Promise<unknown>)
-        | null = (this as any).$_routerLayout_notifyRouteUpdate
-      if (notify) {
-        await notify(to)
-      }
-      next()
-    },
-  })
+function install() {
+  console.info(
+    '[vue-router-layout] Vue.use(VueRouterLayout) is no longer needed. You can sefely remove it.'
+  )
 }
 
 export function createRouterLayout(
@@ -113,54 +99,41 @@ export function createRouterLayout(
       return {
         layoutName: undefined as string | undefined,
         layouts: shallowReactive(
-          Object.create(null) as Record<string, ConcreteComponent>
+          Object.create(null) as Record<string, Component>
         ),
-      }
-    },
-
-    watch: {
-      layoutName(name: string | undefined) {
-        if (name && !this.layouts[name]) {
-          this.layouts[name] = defineAsyncComponent(() =>
-            resolve(name)
-          ) as ConcreteComponent
-        }
-      },
-    },
-
-    provide() {
-      return {
-        $_routerLayout_notifyRouteUpdate: async (
-          to: RouteLocationNormalized
-        ) => {
-          await loadAsyncComponents(to)
-          this.layoutName = resolveLayoutName(to.matched) || this.layoutName
-        },
-      }
-    },
-
-    beforeCreate() {
-      if (
-        process.env.NODE_ENV !== 'production' &&
-        !(this as any).$_routerLayout_installed
-      ) {
-        console.error(
-          '[vue-router-layout] Call app.use(VueRouterLayout) before using the layout component.'
-        )
       }
     },
 
     async beforeRouteEnter(to, _from, next) {
       await loadAsyncComponents(to)
+
+      const name = resolveLayoutName(to.matched)
+      const layoutComp = name
+        ? normalizeEsModuleComponent(await resolve(name))
+        : undefined
+
       next((vm: any) => {
-        vm.layoutName = resolveLayoutName(to.matched) || vm.layoutName
+        vm.layoutName = name
+        if (name && layoutComp) {
+          vm.layouts[name] = layoutComp
+        }
       })
     },
 
     async beforeRouteUpdate(to, _from, next) {
-      await loadAsyncComponents(to)
-      this.layoutName = resolveLayoutName(to.matched) || this.layoutName
-      next()
+      try {
+        await loadAsyncComponents(to)
+
+        const name = resolveLayoutName(to.matched) || this.layoutName
+        if (name && !this.layouts[name]) {
+          this.layouts[name] = normalizeEsModuleComponent(await resolve(name))
+        }
+
+        this.layoutName = name
+        next()
+      } catch (error) {
+        next(error)
+      }
     },
 
     render(): VNode {
@@ -168,7 +141,7 @@ export function createRouterLayout(
       if (!layout) {
         return h('span')
       }
-      return h(layout, {
+      return h(layout as ConcreteComponent, {
         key: this.layoutName,
       })
     },

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RouterLayout component hooks errors while loading a layout 1`] = `"<div>Foo <p>Test1</p></div>"`;
+
+exports[`RouterLayout component hooks errors while loading a lazy component 1`] = `"<div>Foo <p>Test1</p></div>"`;
+
 exports[`RouterLayout component prioritizes mixins option than extends 1`] = `"<div>Bar <p>component</p></div>"`;
 
 exports[`RouterLayout component pulls layout value from extends 1`] = `"<div>Foo <p>component</p></div>"`;


### PR DESCRIPTION
Currently, loading layout components and lazy components on routes are done outside router hooks. This makes it harder to handle an error if it happens during the component loading.

This PR moves the loading logic into the router hooks (`beforeRouteEnter`/`beforeRouteUpdate`) so that it can pass an error to vue-router if it happens. Then, the user can handle the error via the vue-router interface as same as other routing errors.

This change also nullifies the need for `app.use(VueRouterLayout)`. Users no longer need to include it.