### PR TITLE
feat: Allow passing props to layout component

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,19 @@ With the above router, if you have `layouts/foo.vue` and `pages/index.vue` like 
 <!-- layouts/foo.vue -->
 <template>
   <div>
-    <h1>Foo Layout</h1>
+    <h1>{{ title }} Foo Layout</h1>
     <router-view/>
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    type: String,
+    default: 'Hello',
+  }
+}
+</script>
 ```
 
 ```vue
@@ -82,8 +91,15 @@ With the above router, if you have `layouts/foo.vue` and `pages/index.vue` like 
 
 <script>
 export default {
-  // You can specify layout component name here (default value is 'default')
-  layout: 'foo'
+  // Specify the layout by either an object or a string. 
+  // The default value is 'default'.
+  layout: {
+    name: 'foo',
+    props: {
+      title: 'Hi'
+    }
+  }
+  // or just `layout: 'foo'` if the layout component doesn't have any props.
 }
 </script>
 ```
@@ -92,7 +108,7 @@ The following html will be rendered when you access `/` route:
 
 ```html
 <div>
-  <h1>Foo Layout</h1>
+  <h1>Hi Foo Layout</h1>
   <p>index.vue</p>
 </div>
 ```

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -4,6 +4,8 @@ exports[`RouterLayout component hooks errors while loading a layout 1`] = `"<div
 
 exports[`RouterLayout component hooks errors while loading a lazy component 1`] = `"<div>Foo <p>Test1</p></div>"`;
 
+exports[`RouterLayout component passes props to layout component 1`] = `"<div>Bar hello<p>Test</p></div>"`;
+
 exports[`RouterLayout component prioritizes mixins option than extends 1`] = `"<div>Bar <p>component</p></div>"`;
 
 exports[`RouterLayout component pulls layout value from extends 1`] = `"<div>Foo <p>component</p></div>"`;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -13,7 +13,13 @@ const layouts: Record<string, Component> = {
   },
 
   bar: {
-    template: '<div>Bar <router-view/></div>',
+    template: '<div>Bar {{ title }}<router-view/></div>',
+    props: {
+      title: {
+        type: String,
+        default: '',
+      },
+    },
   },
 }
 
@@ -46,10 +52,9 @@ async function mount(children: RouteRecordRaw[]) {
       plugins: [router],
     },
   })
+
   await router.push('/')
-  await wrapper.vm.$nextTick()
-  await wrapper.vm.$nextTick()
-  await wrapper.vm.$nextTick()
+
   return wrapper
 }
 
@@ -405,5 +410,26 @@ describe('RouterLayout component', () => {
 
     expect(wrapper.html()).toMatchSnapshot()
     expect(onError).toHaveBeenCalledWith(new Error('Not found layout: error'))
+  })
+
+  it('passes props to layout component', async () => {
+    const TestComponent = {
+      template: `<p>Test</p>`,
+      layout: {
+        name: 'bar',
+        props: {
+          title: 'hello',
+        },
+      },
+    }
+
+    const wrapper = await mount([
+      {
+        path: '',
+        component: TestComponent,
+      },
+    ])
+
+    expect(wrapper.html()).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Add the ability to pass props to layout component.
Solves https://github.com/ktsn/vue-cli-plugin-auto-routing/issues/61 with no breaking changes.

For some reason, the jest snapshot didn't match when I run the test before I have added any changes, seems like the output html get extra new lines and white spaces, but the structure is the same as before, so I updated the snapshot.