### PR TITLE
Fix: #333 Fix the created hook in page is wrongly called when layout changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,12 @@ export function createRouterLayout(
 
     render(): VNode | null {
       const layoutComponent = this.layout && this.layouts[this.layout.name]
-      if (!layoutComponent) {
+      const currentLayout = resolveLayout(this.$route.matched)
+
+      if (
+        !layoutComponent ||
+        (currentLayout && this.layout?.name !== currentLayout.name)
+      ) {
         return null
       }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -432,4 +432,38 @@ describe('RouterLayout component', () => {
 
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('Created hook in page component should not be called when layout changes', async (done) => {
+    const created = jest.fn()
+
+    const Test1 = {
+      layout: 'foo',
+      template: '<p>Test1</p>',
+      created,
+    }
+
+    const Test2 = {
+      layout: 'bar',
+      template: '<p>Test2</p>',
+    }
+
+    const wrapper = await mount([
+      {
+        path: '',
+        component: Test1,
+      },
+      {
+        path: 'test',
+        component: Test2,
+      },
+    ])
+
+    wrapper.vm.$router.push('/test')
+
+    setTimeout(() => {
+      // Should be called only once when initiating.
+      expect(created).toHaveBeenCalledTimes(1)
+      done()
+    }, 200)
+  })
 })


### PR DESCRIPTION
Fix: #333 
Check the current layout and resolved the layout component can prevent unnecessary render.