### PR TITLE
fix: support omit name props

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,6 @@ import {
 import { RouteRecord, RouteLocationNormalized } from 'vue-router'
 
 type Layout = { name: string; props: Record<string, unknown> }
-type Optional<Object, Key extends keyof Object> = Omit<Object, Key> &
-  Partial<Pick<Object, Key>>
 
 function normalizeLayout(layout: any): Layout {
   if (typeof layout === 'string') {
@@ -186,6 +184,6 @@ export default {
 
 declare module '@vue/runtime-core' {
   interface ComponentCustomOptions {
-    layout?: string | Optional<Layout, 'props'>
+    layout?: string | Partial<Layout>
   }
 }


### PR DESCRIPTION
If you want to use props in the default layout, you need to specify 'default' for the key named name.

```vue
# pages/index.vue
export default defineComponent({
  layout: {
    name: 'default',
    props: { title: 'sample text' },
  }
})
```

I think it is redundant to write `default` every time. What do you think of my suggestion?
thank you.